### PR TITLE
Fixed an issue where PMD checks aren't run as a part of GitHub actions

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -29,4 +29,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -e clean test --file pom.xml
+      run: mvn -e clean test verify --file pom.xml

--- a/.github/workflows/maven_ubuntu.yml
+++ b/.github/workflows/maven_ubuntu.yml
@@ -29,4 +29,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -e clean test --file pom.xml
+      run: mvn -e clean test verify --file pom.xml

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -29,4 +29,4 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
     - name: Build with Maven
-      run: mvn -e clean test --file pom.xml
+      run: mvn -e clean test verify --file pom.xml

--- a/.github/workflows/package_publish.yml
+++ b/.github/workflows/package_publish.yml
@@ -24,7 +24,7 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Build with Maven
-        run: mvn -e -X -B package --file pom.xml
+        run: mvn -e -X -B package verify --file pom.xml
 
       - name: Publish to GitHub Packages Apache Maven
         run: mvn deploy -e -X -s $GITHUB_WORKSPACE/settings.xml


### PR DESCRIPTION
## Description
Closes #9.
Added the verify phase to be run in all GitHub actions.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      Not applicable.
- [x] **All methods have documentation comments.**
      Not applicable.
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
      Not applicable.
- [x] **All information to be logged/displayed to the user are internationalized.** If not, explain why. 
      Not applicable.
- [x] **README.md has been updated if needed.**
      Not applicable.

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**
      Not applicable.